### PR TITLE
fix: correct model name casing from PascalCase to camelCase in generated Prisma client calls

### DIFF
--- a/src/generators/code-generator.ts
+++ b/src/generators/code-generator.ts
@@ -315,7 +315,7 @@ export { ${routerName}Procedures };
 
   private generateRelationProcedures(model: PrismaModel): string {
     const modelName = model.name;
-    const modelVar = modelName.toLowerCase();
+    const modelVar = modelName.charAt(0).toLowerCase() + modelName.slice(1);
     const relFields = model.fields.filter(
       (f: PrismaField) => f.relationName && f.kind === 'object'
     );

--- a/src/generators/test-generator.ts
+++ b/src/generators/test-generator.ts
@@ -38,7 +38,7 @@ export class TestGenerator {
 
     testFile.addStatements(`
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { ${model.name.toLowerCase()}sRouter } from '../../routers/models/${model.name}.router';
+import { ${model.name.charAt(0).toLowerCase() + model.name.slice(1)}sRouter } from '../../routers/models/${model.name}.router';
 import { createMockContext, MockContext } from '../utils/mock-context';
 
 describe('${model.name} Router', () => {
@@ -47,7 +47,7 @@ describe('${model.name} Router', () => {
 
   beforeEach(() => {
     mockContext = createMockContext();
-    router = ${model.name.toLowerCase()}sRouter;
+    router = ${model.name.charAt(0).toLowerCase() + model.name.slice(1)}sRouter;
   });
 
   afterEach(() => {
@@ -59,13 +59,13 @@ describe('${model.name} Router', () => {
       const input = ${JSON.stringify(this.generateTestData(model, 1, false, true), null, 6)};
       
       const expectedResult = { id: '1', ...input, ${this.generateTimestampFields()} };
-      mockContext.prisma.${model.name.toLowerCase()}.create.mockResolvedValue(expectedResult);
+      mockContext.prisma.${model.name.charAt(0).toLowerCase() + model.name.slice(1)}.create.mockResolvedValue(expectedResult);
 
-      const result = await router.${model.name.toLowerCase()}Create['~orpc'].handler({ input, context: mockContext });
+      const result = await router.${model.name.charAt(0).toLowerCase() + model.name.slice(1)}Create['~orpc'].handler({ input, context: mockContext });
 
       expect(result.success).toBe(true);
       expect(result.data).toEqual(expectedResult);
-      expect(mockContext.prisma.${model.name.toLowerCase()}.create).toHaveBeenCalledWith({
+      expect(mockContext.prisma.${model.name.charAt(0).toLowerCase() + model.name.slice(1)}.create).toHaveBeenCalledWith({
         data: input
       });
     });
@@ -79,17 +79,17 @@ describe('${model.name} Router', () => {
         { id: '2', ...${JSON.stringify(this.generateTestData(model, 2, false, true), null, 8)}, ${this.generateTimestampFields()} }
       ];
 
-      mockContext.prisma.${model.name.toLowerCase()}.findMany.mockResolvedValue(mockData);
-      mockContext.prisma.${model.name.toLowerCase()}.count.mockResolvedValue(2);
+      mockContext.prisma.${model.name.charAt(0).toLowerCase() + model.name.slice(1)}.findMany.mockResolvedValue(mockData);
+      mockContext.prisma.${model.name.charAt(0).toLowerCase() + model.name.slice(1)}.count.mockResolvedValue(2);
 
-      const result = await router.${model.name.toLowerCase()}FindMany['~orpc'].handler({ 
+      const result = await router.${model.name.charAt(0).toLowerCase() + model.name.slice(1)}FindMany['~orpc'].handler({ 
         input: { take: 10, skip: 0 }, 
         context: mockContext 
       });
 
       expect(result.success).toBe(true);
       expect(result.data).toEqual(mockData);
-      expect(mockContext.prisma.${model.name.toLowerCase()}.findMany).toHaveBeenCalledWith({
+      expect(mockContext.prisma.${model.name.charAt(0).toLowerCase() + model.name.slice(1)}.findMany).toHaveBeenCalledWith({
         take: 10,
         skip: 0
       });
@@ -100,25 +100,25 @@ describe('${model.name} Router', () => {
     it('should return a single ${model.name}', async () => {
       const mockData = { id: '1', ...${JSON.stringify(this.generateTestData(model, 1, false, true), null, 6)}, ${this.generateTimestampFields()} };
       
-      mockContext.prisma.${model.name.toLowerCase()}.findUnique.mockResolvedValue(mockData);
+      mockContext.prisma.${model.name.charAt(0).toLowerCase() + model.name.slice(1)}.findUnique.mockResolvedValue(mockData);
 
-      const result = await router.${model.name.toLowerCase()}FindById['~orpc'].handler({ 
+      const result = await router.${model.name.charAt(0).toLowerCase() + model.name.slice(1)}FindById['~orpc'].handler({ 
         input: { id: '1' }, 
         context: mockContext 
       });
 
       expect(result.success).toBe(true);
       expect(result.data).toEqual(mockData);
-      expect(mockContext.prisma.${model.name.toLowerCase()}.findUnique).toHaveBeenCalledWith({
+      expect(mockContext.prisma.${model.name.charAt(0).toLowerCase() + model.name.slice(1)}.findUnique).toHaveBeenCalledWith({
         where: { id: '1' }
       });
     });
 
     it('should throw NOT_FOUND when ${model.name} does not exist', async () => {
-      mockContext.prisma.${model.name.toLowerCase()}.findUnique.mockResolvedValue(null);
+      mockContext.prisma.${model.name.charAt(0).toLowerCase() + model.name.slice(1)}.findUnique.mockResolvedValue(null);
 
       await expect(
-        router.${model.name.toLowerCase()}FindById['~orpc'].handler({ 
+        router.${model.name.charAt(0).toLowerCase() + model.name.slice(1)}FindById['~orpc'].handler({ 
           input: { id: 'non-existent' }, 
           context: mockContext 
         })
@@ -131,16 +131,16 @@ describe('${model.name} Router', () => {
       const updateData = ${JSON.stringify(this.generateTestData(model, 1, true, true), null, 6)};
       const updatedResult = { id: '1', ...updateData, ${this.generateTimestampFields()} };
       
-      mockContext.prisma.${model.name.toLowerCase()}.update.mockResolvedValue(updatedResult);
+      mockContext.prisma.${model.name.charAt(0).toLowerCase() + model.name.slice(1)}.update.mockResolvedValue(updatedResult);
 
-      const result = await router.${model.name.toLowerCase()}Update['~orpc'].handler({ 
+      const result = await router.${model.name.charAt(0).toLowerCase() + model.name.slice(1)}Update['~orpc'].handler({ 
         input: { where: { id: '1' }, data: updateData }, 
         context: mockContext 
       });
 
       expect(result.success).toBe(true);
       expect(result.data).toEqual(updatedResult);
-      expect(mockContext.prisma.${model.name.toLowerCase()}.update).toHaveBeenCalledWith({
+      expect(mockContext.prisma.${model.name.charAt(0).toLowerCase() + model.name.slice(1)}.update).toHaveBeenCalledWith({
         where: { id: '1' },
         data: updateData
       });
@@ -205,19 +205,19 @@ ${models
       const createData = ${JSON.stringify(this.generateTestData(model), null, 6)};
       
       // TODO: Implement actual integration test
-      // const created = await client.${model.name.toLowerCase()}.create(createData);
+      // const created = await client.${model.name.charAt(0).toLowerCase() + model.name.slice(1)}.create(createData);
       // expect(created.success).toBe(true);
       // expect(created.data).toMatchObject(createData);
       
       // Read
-      // const found = await client.${model.name.toLowerCase()}.findUnique({ id: created.data.id });
+      // const found = await client.${model.name.charAt(0).toLowerCase() + model.name.slice(1)}.findUnique({ id: created.data.id });
       // expect(found.success).toBe(true);
       // expect(found.data).toMatchObject(createData);
       
       // Update
       // TODO: Implement update test
       // const updateData = { /* sample data */ };
-      // const updated = await client.${model.name.toLowerCase()}.update({ 
+      // const updated = await client.${model.name.charAt(0).toLowerCase() + model.name.slice(1)}.update({ 
       //   where: { id: created.data.id },
       //   data: updateData 
       // });
@@ -225,13 +225,13 @@ ${models
       // expect(updated.data).toMatchObject(updateData);
       
       // Delete
-      // const deleted = await client.${model.name.toLowerCase()}.delete({ id: created.data.id });
+      // const deleted = await client.${model.name.charAt(0).toLowerCase() + model.name.slice(1)}.delete({ id: created.data.id });
       // expect(deleted.success).toBe(true);
     });
 
     it('should handle list operations with pagination', async () => {
       // TODO: Implement pagination test
-      // const result = await client.${model.name.toLowerCase()}.findMany({ take: 10, skip: 0 });
+      // const result = await client.${model.name.charAt(0).toLowerCase() + model.name.slice(1)}.findMany({ take: 10, skip: 0 });
       // expect(result.success).toBe(true);
       // expect(result.meta.pagination).toBeDefined();
     });

--- a/src/utils/code-generation-utils.ts
+++ b/src/utils/code-generation-utils.ts
@@ -290,7 +290,7 @@ function generateHandlerCode(
   config: Config,
   model: CodeGenModel
 ): string {
-  const modelVar = modelName.toLowerCase();
+  const modelVar = modelName.charAt(0).toLowerCase() + modelName.slice(1);
   const _isWrite = [
     'create',
     'createMany',

--- a/tests/integration/model-name-casing.test.ts
+++ b/tests/integration/model-name-casing.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it, vi, afterAll } from 'vitest';
+import { promises as fs } from 'fs';
+import path from 'path';
+
+// Mock prisma internals to avoid heavy DMMF generation in tests
+vi.mock('@prisma/internals', () => ({
+  getDMMF: async () => ({
+    datamodel: {
+      models: [
+        {
+          name: 'AccommodationPricing',
+          dbName: null,
+          fields: [
+            { name: 'id', kind: 'scalar', type: 'String', isId: true },
+            { name: 'price', kind: 'scalar', type: 'Float' }
+          ]
+        },
+        {
+          name: 'UserAccount',
+          dbName: null,
+          fields: [
+            { name: 'id', kind: 'scalar', type: 'String', isId: true },
+            { name: 'username', kind: 'scalar', type: 'String' }
+          ]
+        },
+        {
+          name: 'Post',
+          dbName: null,
+          fields: [
+            { name: 'id', kind: 'scalar', type: 'String', isId: true },
+            { name: 'title', kind: 'scalar', type: 'String' }
+          ]
+        }
+      ]
+    },
+    mappings: {
+      modelOperations: [
+        {
+          model: 'AccommodationPricing',
+          findUnique: 'findUniqueAccommodationPricing',
+          findMany: 'findManyAccommodationPricing',
+          create: 'createOneAccommodationPricing',
+          update: 'updateOneAccommodationPricing',
+          delete: 'deleteOneAccommodationPricing',
+          count: 'countAccommodationPricing',
+          aggregate: 'aggregateAccommodationPricing'
+        },
+        {
+          model: 'UserAccount',
+          findUnique: 'findUniqueUserAccount',
+          findMany: 'findManyUserAccount',
+          create: 'createOneUserAccount',
+          update: 'updateOneUserAccount',
+          delete: 'deleteOneUserAccount',
+          count: 'countUserAccount',
+          aggregate: 'aggregateUserAccount'
+        },
+        {
+          model: 'Post',
+          findUnique: 'findUniquePost',
+          findMany: 'findManyPost',
+          create: 'createOnePost',
+          update: 'updateOnePost',
+          delete: 'deleteOnePost',
+          count: 'countPost',
+          aggregate: 'aggregatePost'
+        }
+      ]
+    }
+  }),
+  parseEnvValue: (v: any) => (typeof v === 'string' ? v : v.value),
+}));
+
+// Import after mocks
+import { ORPCGenerator } from '../../src/generators/orpc-generator';
+
+// Test datamodel with PascalCase model names that should convert to camelCase in Prisma client
+const datamodel = `
+model AccommodationPricing {
+  id    String @id @default(cuid())
+  price Float
+}
+
+model UserAccount {
+  id       String @id @default(cuid())
+  username String
+}
+
+model Post {
+  id    String @id @default(cuid())
+  title String
+}
+`;
+
+function createOptions(): any {
+  return {
+    generator: {
+      config: { 
+        output: './temp-test-output',
+        generateDocumentation: 'false',
+        generateTests: 'false',
+        schemaLibrary: 'zod'
+      },
+      output: { value: './temp-test-output' }
+    },
+    otherGenerators: [{ provider: { value: 'prisma-client-js', fromEnvVar: null } }],
+    datamodel,
+    schemaPath: 'schema.prisma'
+  };
+}
+
+describe('Model Name Casing in Generated Code', () => {
+  const outputDir = './temp-test-output';
+
+  afterAll(async () => {
+    // Clean up test output directory
+    try {
+      await fs.rm(outputDir, { recursive: true, force: true });
+    } catch {
+      // Ignore cleanup errors
+    }
+  });
+
+  it('generates correct camelCase model names for Prisma client calls', async () => {
+    const opts = createOptions();
+    const generator = new ORPCGenerator(opts);
+    
+    // Generate the code
+    await generator.generate();
+
+    // Read the generated router files and verify they use correct camelCase
+    const accommodationPricingRouter = path.join(outputDir, 'routers', 'models', 'AccommodationPricing.router.ts');
+    const userAccountRouter = path.join(outputDir, 'routers', 'models', 'UserAccount.router.ts');
+    const postRouter = path.join(outputDir, 'routers', 'models', 'Post.router.ts');
+
+    // Check AccommodationPricing -> accommodationPricing (camelCase)
+    const accommodationContent = await fs.readFile(accommodationPricingRouter, 'utf8');
+    expect(accommodationContent).toMatch(/ctx\.prisma\.accommodationPricing\./);
+    expect(accommodationContent).not.toMatch(/ctx\.prisma\.accommodationpricing\./); // Should not contain lowercase
+
+    // Check UserAccount -> userAccount (camelCase)
+    const userContent = await fs.readFile(userAccountRouter, 'utf8');
+    expect(userContent).toMatch(/ctx\.prisma\.userAccount\./);
+    expect(userContent).not.toMatch(/ctx\.prisma\.useraccount\./); // Should not contain lowercase
+
+    // Check Post -> post (already lowercase, should remain post)
+    const postContent = await fs.readFile(postRouter, 'utf8');
+    expect(postContent).toMatch(/ctx\.prisma\.post\./);
+  });
+
+  it('verifies specific Prisma operations use correct camelCase', async () => {
+    const opts = createOptions();
+    const generator = new ORPCGenerator(opts);
+    
+    await generator.generate();
+
+    const accommodationPricingRouter = path.join(outputDir, 'routers', 'models', 'AccommodationPricing.router.ts');
+    const content = await fs.readFile(accommodationPricingRouter, 'utf8');
+
+    // Test common Prisma operations with correct camelCase
+    expect(content).toMatch(/ctx\.prisma\.accommodationPricing\.findUnique/);
+    expect(content).toMatch(/ctx\.prisma\.accommodationPricing\.findMany/);
+    expect(content).toMatch(/ctx\.prisma\.accommodationPricing\.create/);
+    expect(content).toMatch(/ctx\.prisma\.accommodationPricing\.update/);
+    expect(content).toMatch(/ctx\.prisma\.accommodationPricing\.delete/);
+    expect(content).toMatch(/ctx\.prisma\.accommodationPricing\.count/);
+    expect(content).toMatch(/ctx\.prisma\.accommodationPricing\.aggregate/);
+
+    // Ensure no lowercase variants exist
+    expect(content).not.toMatch(/ctx\.prisma\.accommodationpricing\./);
+  });
+
+  it('correctly handles edge cases in model name conversion', () => {
+    // Test the camelCase conversion logic directly
+    const testCases = [
+      { input: 'AccommodationPricing', expected: 'accommodationPricing' },
+      { input: 'UserAccount', expected: 'userAccount' },
+      { input: 'Post', expected: 'post' },
+      { input: 'APIKey', expected: 'aPIKey' },
+      { input: 'XMLHttpRequest', expected: 'xMLHttpRequest' },
+      { input: 'HTMLElement', expected: 'hTMLElement' }
+    ];
+
+    testCases.forEach(({ input, expected }) => {
+      const result = input.charAt(0).toLowerCase() + input.slice(1);
+      expect(result).toBe(expected);
+    });
+  });
+});


### PR DESCRIPTION
# Fix: Correct Model Name Casing from PascalCase to camelCase

## Summary

This PR fixes GitHub issue #34 where the generator was producing incorrect lowercase model names (e.g., `accommodationpricing`) instead of the proper camelCase (`accommodationPricing`) that Prisma client expects.

## Problem

When generating oRPC routers for models with PascalCase names like `AccommodationPricing`, the generator was using `modelName.toLowerCase()` which resulted in:

❌ **Before**: `ctx.prisma.accommodationpricing.findUnique()`  
✅ **After**: `ctx.prisma.accommodationPricing.findUnique()`

This caused TypeScript errors since PrismaClient expects camelCase property names.

## Changes

- **🔧 Fixed model name conversion logic** in `src/utils/code-generation-utils.ts`
- **🔧 Fixed relation procedures** in `src/generators/code-generator.ts` 
- **🔧 Updated test generator templates** in `src/generators/test-generator.ts`
- **✅ Added comprehensive test suite** in `tests/integration/model-name-casing.test.ts`

## Test Plan

✅ All existing tests pass  
✅ New integration tests verify correct camelCase conversion:
- `AccommodationPricing` → `accommodationPricing`
- `UserAccount` → `userAccount`
- `Post` → `post`

✅ Verified with `pnpm run example:basic:prepare` - generated code now uses correct casing

## Breaking Changes

None - this is a bug fix that makes the generated code work correctly with Prisma client.

Closes #34